### PR TITLE
伐採ストラテジを修正した

### DIFF
--- a/src/main/java/me/enchan/minerstools/MinersToolsMod.java
+++ b/src/main/java/me/enchan/minerstools/MinersToolsMod.java
@@ -14,6 +14,7 @@ import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
@@ -36,7 +37,8 @@ public class MinersToolsMod implements ModInitializer {
             if (!toolStatusByPlayer.getOrDefault(player.getUuid(), false)) {
                 return;
             }
-            BulkBreakDispatcher.onBreakBlock(world, origin, player, state);
+
+            BulkBreakDispatcher.onBreakBlock((ServerWorld) world, origin, player, state);
         });
 
         ServerPlayNetworking.registerGlobalReceiver(MinersToolsModeTogglePayload.ID, (payload, context) -> {

--- a/src/main/java/me/enchan/minerstools/bulk_break/BulkBreakDispatcher.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/BulkBreakDispatcher.java
@@ -8,8 +8,8 @@ import me.enchan.minerstools.bulk_break.strategy.HarvestingStrategy;
 import me.enchan.minerstools.bulk_break.strategy.MiningStrategy;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 public class BulkBreakDispatcher {
     private static final List<BulkBreakStrategy> Strategies = List.of(
@@ -18,7 +18,7 @@ public class BulkBreakDispatcher {
             new HarvestingStrategy());
 
     public static void onBreakBlock(
-            World world,
+            ServerWorld world,
             BlockPos origin,
             PlayerEntity player,
             BlockState originState) {

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/BulkBreakStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/BulkBreakStrategy.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -20,11 +19,12 @@ public interface BulkBreakStrategy {
 
     /** ブロックを破壊する */
     default void harvest(World world, BlockPos pos, PlayerEntity player) {
-        if (player instanceof ServerPlayerEntity serverPlayer) {
-            serverPlayer.interactionManager.tryBreakBlock(pos);
-        } else {
-            // フォールバック
-            world.breakBlock(pos, true, player);
-        }
+        world.breakBlock(pos, true, player);
+        // if (player instanceof ServerPlayerEntity serverPlayer) {
+        // serverPlayer.interactionManager.tryBreakBlock(pos);
+        // } else {
+        // // フォールバック
+        // world.breakBlock(pos, true, player);
+        // }
     }
 }

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/BulkBreakStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/BulkBreakStrategy.java
@@ -2,11 +2,15 @@ package me.enchan.minerstools.bulk_break.strategy;
 
 import java.util.Set;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.stat.Stats;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 /** 範囲破壊ストラテジ */
 public interface BulkBreakStrategy {
@@ -15,16 +19,30 @@ public interface BulkBreakStrategy {
     boolean matches(BlockState state, PlayerEntity player, ItemStack tool);
 
     /** 起点ブロックから破壊すべき対象座標を収集する */
-    Set<BlockPos> collectTargets(World world, BlockPos origin, BlockState originState);
+    Set<BlockPos> collectTargets(ServerWorld world, BlockPos origin, BlockState originState);
 
     /** ブロックを破壊する */
-    default void harvest(World world, BlockPos pos, PlayerEntity player) {
-        world.breakBlock(pos, true, player);
-        // if (player instanceof ServerPlayerEntity serverPlayer) {
-        // serverPlayer.interactionManager.tryBreakBlock(pos);
-        // } else {
-        // // フォールバック
-        // world.breakBlock(pos, true, player);
-        // }
+    default void harvest(ServerWorld world, BlockPos pos, PlayerEntity player) {
+        var tool = player.getMainHandStack();
+        var state = world.getBlockState(pos);
+
+        // アイテムがドロップできる場合
+        var shouldDropItem = !player.isCreative() && (!state.isToolRequired() || tool.isSuitableFor(state));
+        if (shouldDropItem) {
+            var blockEntity = world.getBlockEntity(pos);
+            Block
+                    .getDroppedStacks(state, world, pos, blockEntity, player, tool)
+                    .forEach(stack -> Block.dropStack(world, pos, stack));
+
+            // シルクタッチなら経験値をドロップしない
+            var isSilkTouch = EnchantmentHelper.getLevel(Enchantments.SILK_TOUCH, tool) > 0;
+            state.onStacksDropped(world, pos, tool, !isSilkTouch);
+        }
+
+        tool.postMine(world, state, pos, player);
+
+        player.incrementStat(Stats.MINED.getOrCreateStat(state.getBlock()));
+        world.removeBlock(pos, false);
+
     }
 }

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.tag.BlockTags;
@@ -13,13 +14,21 @@ import net.minecraft.world.World;
 
 /** 伐採ストラテジ */
 public class FellingStrategy implements BulkBreakStrategy {
+
+    private enum FellingMode {
+        TREE,
+        MUSHROOM,
+        WARP_TREE,
+        CRIMSON_TREE
+    }
+
     @Override
     public boolean matches(
             BlockState state,
             PlayerEntity player,
             ItemStack tool) {
-        // 葉から破壊することはない想定
-        return state.isIn(BlockTags.LOGS);
+        var mode = classifyFellingMode(state);
+        return isNode(mode, state);
     }
 
     @Override
@@ -27,19 +36,21 @@ public class FellingStrategy implements BulkBreakStrategy {
             World world,
             BlockPos origin,
             BlockState originState) {
-        var visited = new HashSet<BlockPos>();
-        var queue = new ArrayDeque<BlockPos>();
+        var marked = new HashSet<BlockPos>();
+        var chainQueue = new ArrayDeque<BlockPos>();
 
-        visited.add(origin);
-        queue.add(origin);
+        var mode = classifyFellingMode(originState);
 
-        while (!queue.isEmpty()) {
-            var center = queue.poll();
+        marked.add(origin);
+        chainQueue.add(origin);
+
+        while (!chainQueue.isEmpty()) {
+            var center = chainQueue.poll();
 
             BlockPos
                     .stream(center.add(-1, -1, -1), center.add(1, 1, 1))
                     .map(BlockPos::toImmutable)
-                    .filter(p -> !visited.contains(p))
+                    .filter(p -> !marked.contains(p))
                     .filter(p -> {
                         // 起点からXZ方向の距離4ブロック以内
                         var flatOrigin = origin.withY(0);
@@ -53,30 +64,30 @@ public class FellingStrategy implements BulkBreakStrategy {
 
                         // 起点と同じブロックなら継続
                         if (pState.getBlock().equals(originState.getBlock())) {
-                            visited.add(p);
-                            queue.add(p);
+                            marked.add(p);
+                            chainQueue.add(p);
                             return;
                         }
 
-                        // 中央が原木で相手が葉なら継続
-                        if (centerState.isIn(BlockTags.LOGS) && pState.isIn(BlockTags.LEAVES)) {
-                            visited.add(p);
-                            queue.add(p);
+                        // 中央がノードで相手がリーフなら継続
+                        if (isNode(mode, centerState) && isLeaf(mode, pState)) {
+                            marked.add(p);
+                            chainQueue.add(p);
                             return;
                         }
 
-                        // 中央が葉の場合、
-                        if (centerState.isIn(BlockTags.LEAVES)) {
-                            // 相手が葉なら継続
-                            if (pState.isIn(BlockTags.LEAVES)) {
-                                visited.add(p);
-                                queue.add(p);
+                        // 中央がリーフの場合、
+                        if (isLeaf(mode, centerState)) {
+                            // 相手がリーフなら継続
+                            if (isLeaf(mode, pState)) {
+                                marked.add(p);
+                                chainQueue.add(p);
                                 return;
                             }
 
-                            // 相手が原木なら連鎖を中止
-                            if (pState.isIn(BlockTags.LOGS)) {
-                                visited.add(p);
+                            // 相手がノードなら連鎖を中止
+                            if (isNode(mode, pState)) {
+                                marked.add(p);
                                 return;
                             }
                         }
@@ -84,7 +95,69 @@ public class FellingStrategy implements BulkBreakStrategy {
         }
 
         // このメソッドが呼び出された時点で起点のブロックは破壊されているので、候補から除外
-        visited.remove(origin);
-        return visited;
+        marked.remove(origin);
+        return marked;
+    }
+
+    private FellingMode classifyFellingMode(BlockState state) {
+        // 歪んだ幹
+        if (state.isIn(BlockTags.WARPED_STEMS)) {
+            return FellingMode.WARP_TREE;
+        }
+
+        // 真紅の幹
+        if (state.isIn(BlockTags.CRIMSON_STEMS)) {
+            return FellingMode.CRIMSON_TREE;
+        }
+
+        // キノコ
+        if (state.isOf(Blocks.MUSHROOM_STEM)) {
+            return FellingMode.MUSHROOM;
+        }
+
+        return FellingMode.TREE;
+    }
+
+    private boolean isNode(FellingMode mode, BlockState state) {
+        if (mode == FellingMode.TREE && state.isIn(BlockTags.LOGS)) {
+            return true;
+        }
+
+        // 歪んだ幹
+        if (mode == FellingMode.WARP_TREE && state.isIn(BlockTags.WARPED_STEMS)) {
+            return true;
+        }
+
+        // 真紅の幹
+        if (mode == FellingMode.CRIMSON_TREE && state.isIn(BlockTags.CRIMSON_STEMS)) {
+            return true;
+        }
+
+        // キノコ
+        if (mode == FellingMode.MUSHROOM && state.isOf(Blocks.MUSHROOM_STEM)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isLeaf(FellingMode mode, BlockState state) {
+        if (mode == FellingMode.TREE && state.isIn(BlockTags.LEAVES)) {
+            return true;
+        }
+
+        // ネザーウォートブロック・シュルームライト
+        if (mode == FellingMode.CRIMSON_TREE
+                && (state.isOf(Blocks.NETHER_WART_BLOCK) || state.isOf(Blocks.SHROOMLIGHT))) {
+            return true;
+        }
+
+        // キノコ
+        if (mode == FellingMode.MUSHROOM
+                && (state.isOf(Blocks.BROWN_MUSHROOM_BLOCK) || state.isOf(Blocks.RED_MUSHROOM_BLOCK))) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
@@ -47,7 +47,9 @@ public class FellingStrategy implements BulkBreakStrategy {
         while (!chainQueue.isEmpty()) {
             var center = chainQueue.poll();
 
-            BlockPos
+            var centerState = center.equals(origin) ? originState : world.getBlockState(center);
+
+            var unmarkedSurroundings = BlockPos
                     .stream(center.add(-1, -1, -1), center.add(1, 1, 1))
                     .map(BlockPos::toImmutable)
                     .filter(p -> !marked.contains(p))
@@ -57,41 +59,28 @@ public class FellingStrategy implements BulkBreakStrategy {
                         var flatPos = p.withY(0);
 
                         return flatPos.isWithinDistance(flatOrigin, 4);
-                    })
-                    .forEach(p -> {
-                        var pState = world.getBlockState(p);
-                        var centerState = world.getBlockState(center);
-
-                        // 起点と同じブロックなら継続
-                        if (pState.getBlock().equals(originState.getBlock())) {
-                            marked.add(p);
-                            chainQueue.add(p);
-                            return;
-                        }
-
-                        // 中央がノードで相手がリーフなら継続
-                        if (isNode(mode, centerState) && isLeaf(mode, pState)) {
-                            marked.add(p);
-                            chainQueue.add(p);
-                            return;
-                        }
-
-                        // 中央がリーフの場合、
-                        if (isLeaf(mode, centerState)) {
-                            // 相手がリーフなら継続
-                            if (isLeaf(mode, pState)) {
-                                marked.add(p);
-                                chainQueue.add(p);
-                                return;
-                            }
-
-                            // 相手がノードなら連鎖を中止
-                            if (isNode(mode, pState)) {
-                                marked.add(p);
-                                return;
-                            }
-                        }
                     });
+
+            unmarkedSurroundings.forEach(p -> {
+                var pState = world.getBlockState(p);
+                if (pState.isAir()) {
+                    return;
+                }
+
+                // 起点と同じブロックなら継続
+                if (pState.getBlock().equals(centerState.getBlock())) {
+                    marked.add(p);
+                    chainQueue.add(p);
+                    return;
+                }
+
+                // 起点がノードで相手がリーフなら継続
+                if (isNode(mode, centerState) && isLeaf(mode, pState)) {
+                    marked.add(p);
+                    chainQueue.add(p);
+                    return;
+                }
+            });
         }
 
         // このメソッドが呼び出された時点で起点のブロックは破壊されているので、候補から除外

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
@@ -9,8 +9,8 @@ import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 /** 伐採ストラテジ */
 public class FellingStrategy implements BulkBreakStrategy {
@@ -33,7 +33,7 @@ public class FellingStrategy implements BulkBreakStrategy {
 
     @Override
     public Set<BlockPos> collectTargets(
-            World world,
+            ServerWorld world,
             BlockPos origin,
             BlockState originState) {
         var marked = new HashSet<BlockPos>();

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/FellingStrategy.java
@@ -34,49 +34,57 @@ public class FellingStrategy implements BulkBreakStrategy {
         queue.add(origin);
 
         while (!queue.isEmpty()) {
-            var pos = queue.poll();
+            var center = queue.poll();
 
             BlockPos
-                    .stream(pos.add(-1, -1, -1), pos.add(1, 1, 1))
+                    .stream(center.add(-1, -1, -1), center.add(1, 1, 1))
                     .map(BlockPos::toImmutable)
                     .filter(p -> !visited.contains(p))
-                    .filter(p -> isInRange(origin, p))
                     .filter(p -> {
-                        // FIXME #6: なんかここおかしい, 木 -> 葉 -> 木 のチェインが成立してしまっている
-                        var state = world.getBlockState(p);
-                        var posState = world.getBlockState(pos);
+                        // 起点からXZ方向の距離4ブロック以内
+                        var flatOrigin = origin.withY(0);
+                        var flatPos = p.withY(0);
 
-                        // 同じブロックか、木 -> 葉 のチェインは継続する。葉 -> 木のチェインは繋がない
-
-                        if (state.getBlock().equals(originState.getBlock())) {
-                            return true;
-                        }
-
-                        if (state.isIn(BlockTags.LEAVES) && posState.isIn(BlockTags.LOGS)) {
-                            return true;
-                        }
-
-                        return false;
+                        return flatPos.isWithinDistance(flatOrigin, 4);
                     })
                     .forEach(p -> {
-                        visited.add(p);
-                        queue.add(p);
+                        var pState = world.getBlockState(p);
+                        var centerState = world.getBlockState(center);
+
+                        // 起点と同じブロックなら継続
+                        if (pState.getBlock().equals(originState.getBlock())) {
+                            visited.add(p);
+                            queue.add(p);
+                            return;
+                        }
+
+                        // 中央が原木で相手が葉なら継続
+                        if (centerState.isIn(BlockTags.LOGS) && pState.isIn(BlockTags.LEAVES)) {
+                            visited.add(p);
+                            queue.add(p);
+                            return;
+                        }
+
+                        // 中央が葉の場合、
+                        if (centerState.isIn(BlockTags.LEAVES)) {
+                            // 相手が葉なら継続
+                            if (pState.isIn(BlockTags.LEAVES)) {
+                                visited.add(p);
+                                queue.add(p);
+                                return;
+                            }
+
+                            // 相手が原木なら連鎖を中止
+                            if (pState.isIn(BlockTags.LOGS)) {
+                                visited.add(p);
+                                return;
+                            }
+                        }
                     });
         }
 
         // このメソッドが呼び出された時点で起点のブロックは破壊されているので、候補から除外
         visited.remove(origin);
         return visited;
-    }
-
-    private Boolean isInRange(BlockPos origin, BlockPos pos) {
-        var xzLimit = 4;
-        var yLimit = 20;
-
-        var dx = Math.abs(pos.getX() - origin.getX());
-        var dz = Math.abs(pos.getZ() - origin.getZ());
-        var dy = Math.abs(pos.getY() - origin.getY());
-
-        return dx <= xzLimit && dz <= xzLimit && dy <= yLimit;
     }
 }

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/HarvestingStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/HarvestingStrategy.java
@@ -8,8 +8,8 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.CropBlock;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 public class HarvestingStrategy implements BulkBreakStrategy {
 
@@ -26,7 +26,7 @@ public class HarvestingStrategy implements BulkBreakStrategy {
     }
 
     @Override
-    public Set<BlockPos> collectTargets(World world, BlockPos origin, BlockState originState) {
+    public Set<BlockPos> collectTargets(ServerWorld world, BlockPos origin, BlockState originState) {
         var originBlock = originState.getBlock();
 
         var visited = new HashSet<BlockPos>();
@@ -69,7 +69,7 @@ public class HarvestingStrategy implements BulkBreakStrategy {
     }
 
     @Override
-    public void harvest(World world, BlockPos pos, PlayerEntity player) {
+    public void harvest(ServerWorld world, BlockPos pos, PlayerEntity player) {
         // TODO: #6 アイテムスタックを見て自動で植え直したい
         BulkBreakStrategy.super.harvest(world, pos, player);
     }

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/MiningStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/MiningStrategy.java
@@ -11,8 +11,8 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.registry.tag.TagKey;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 public class MiningStrategy implements BulkBreakStrategy {
 
@@ -34,7 +34,7 @@ public class MiningStrategy implements BulkBreakStrategy {
     }
 
     @Override
-    public Set<BlockPos> collectTargets(World world, BlockPos origin, BlockState originState) {
+    public Set<BlockPos> collectTargets(ServerWorld world, BlockPos origin, BlockState originState) {
         var visited = new HashSet<BlockPos>();
         var queue = new ArrayDeque<BlockPos>();
 


### PR DESCRIPTION
Fixes: #10

共通の破壊処理におかしな部分があったため、合わせて修正しています。

- **fix: #10 連鎖ロジックを修正**
- **feat: #10 キノコ, 歪んだ木, 真紅の木に対応**
- **fix: #10 破壊処理を修正, 伐採ロジックを分割**
- **fix: #10 採掘ストラテジを修正**
