### PR TITLE
ワンショット一括破壊ストラテジを実装した

### DIFF
--- a/src/client/java/me/enchan/minerstools/MinersToolsModClient.java
+++ b/src/client/java/me/enchan/minerstools/MinersToolsModClient.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import me.enchan.minerstools.payloads.MinersToolsModeTogglePayload;
+import me.enchan.minerstools.payloads.MinersToolsOneshotTriggerPayload;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
@@ -17,6 +18,8 @@ public class MinersToolsModClient implements ClientModInitializer {
 
     public static KeyBinding modeToggleKey;
 
+    public static KeyBinding oneshotTriggerKey;
+
     @Override
     public void onInitializeClient() {
         Logger.info("miners-tools:client");
@@ -28,9 +31,20 @@ public class MinersToolsModClient implements ClientModInitializer {
                         GLFW.GLFW_KEY_Z,
                         "category.miners-tools"));
 
+        oneshotTriggerKey = KeyBindingHelper.registerKeyBinding(
+                new KeyBinding(
+                        "key.miners-tools.oneshot-trigger",
+                        InputUtil.Type.KEYSYM,
+                        GLFW.GLFW_KEY_R,
+                        "category.miners-tools"));
+
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (modeToggleKey.wasPressed()) {
                 ClientPlayNetworking.send(new MinersToolsModeTogglePayload());
+            }
+
+            while (oneshotTriggerKey.wasPressed()) {
+                ClientPlayNetworking.send(new MinersToolsOneshotTriggerPayload());
             }
         });
     }

--- a/src/main/java/me/enchan/minerstools/MinersToolsMod.java
+++ b/src/main/java/me/enchan/minerstools/MinersToolsMod.java
@@ -11,6 +11,7 @@ import me.enchan.minerstools.auto_tool.AutoToolSwitcher;
 import me.enchan.minerstools.bulk_break.BulkBreakDispatcher;
 import me.enchan.minerstools.events.MinersToolsMainHandToolBreakEvent;
 import me.enchan.minerstools.payloads.MinersToolsModeTogglePayload;
+import me.enchan.minerstools.payloads.MinersToolsOneshotTriggerPayload;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
@@ -25,40 +26,52 @@ public class MinersToolsMod implements ModInitializer {
 
     public static final Logger Logger = LoggerFactory.getLogger("miners-tools");
 
-    private static final Map<UUID, Boolean> toolStatusByPlayer = new HashMap<>();
+    private static final Map<UUID, Boolean> modeByPlayer = new HashMap<>();
 
-    private BulkBreakDispatcher dispatcher = new BulkBreakDispatcher();
+    private static final Map<UUID, Boolean> oneshotToggleByPlayer = new HashMap<>();
 
     @Override
     public void onInitialize() {
         Logger.info("miners-tools");
 
+        // ペイロードを登録
         PayloadTypeRegistry.playC2S().register(
                 MinersToolsModeTogglePayload.ID,
                 MinersToolsModeTogglePayload.CODEC);
 
+        PayloadTypeRegistry.playC2S().register(
+                MinersToolsOneshotTriggerPayload.ID,
+                MinersToolsOneshotTriggerPayload.CODEC);
+
+        // レシーバ: ブロック破壊時
         PlayerBlockBreakEvents.AFTER.register((world, player, origin, state, blockEntity) -> {
-            if (!toolStatusByPlayer.getOrDefault(player.getUuid(), false)) {
+            if (!modeByPlayer.getOrDefault(player.getUuid(), false)) {
                 return;
             }
 
-            dispatcher.dispatchStrategy((ServerWorld) world, origin, player, state);
+            var isOneshotMode = oneshotToggleByPlayer.get(player.getUuid());
+
+            BulkBreakDispatcher.dispatchStrategy((ServerWorld) world, origin, player, state, isOneshotMode);
+
+            oneshotToggleByPlayer.put(player.getUuid(), false);
         });
 
+        // レシーバ: ツール破壊時
         MinersToolsMainHandToolBreakEvent.EVENT.register(player -> {
-            if (!toolStatusByPlayer.getOrDefault(player.getUuid(), false)) {
+            if (!modeByPlayer.getOrDefault(player.getUuid(), false)) {
                 return;
             }
 
             AutoToolSwitcher.onBreakMainhandTool(player);
         });
 
+        // レシーバ: モード切り替えペイロード
         ServerPlayNetworking.registerGlobalReceiver(MinersToolsModeTogglePayload.ID, (payload, context) -> {
             ServerPlayerEntity player = context.player();
 
-            var currentMode = toolStatusByPlayer.getOrDefault(player.getUuid(), false);
+            var currentMode = modeByPlayer.getOrDefault(player.getUuid(), false);
             var isEnabled = !currentMode;
-            toolStatusByPlayer.put(player.getUuid(), isEnabled);
+            modeByPlayer.put(player.getUuid(), isEnabled);
 
             Text message = Text.empty()
                     .append(Text.literal("Miners tools: "))
@@ -66,6 +79,18 @@ public class MinersToolsMod implements ModInitializer {
                             ? Text.literal("ON").formatted(Formatting.GREEN)
                             : Text.literal("OFF").formatted(Formatting.RED));
             player.sendMessage(message, true);
+        });
+
+        // レシーバ: ワンショットトリガペイロード
+        ServerPlayNetworking.registerGlobalReceiver(MinersToolsOneshotTriggerPayload.ID, (payload, context) -> {
+            ServerPlayerEntity player = context.player();
+            var currentMode = modeByPlayer.getOrDefault(player.getUuid(), false);
+            if (!currentMode) {
+                return;
+            }
+
+            oneshotToggleByPlayer.put(player.getUuid(), true);
+            player.sendMessage(Text.literal("ONESHOT break mode!").formatted(Formatting.YELLOW), true);
         });
 
     }

--- a/src/main/java/me/enchan/minerstools/MinersToolsMod.java
+++ b/src/main/java/me/enchan/minerstools/MinersToolsMod.java
@@ -27,6 +27,8 @@ public class MinersToolsMod implements ModInitializer {
 
     private static final Map<UUID, Boolean> toolStatusByPlayer = new HashMap<>();
 
+    private BulkBreakDispatcher dispatcher = new BulkBreakDispatcher();
+
     @Override
     public void onInitialize() {
         Logger.info("miners-tools");
@@ -40,7 +42,7 @@ public class MinersToolsMod implements ModInitializer {
                 return;
             }
 
-            BulkBreakDispatcher.onBreakBlock((ServerWorld) world, origin, player, state);
+            dispatcher.dispatchStrategy((ServerWorld) world, origin, player, state);
         });
 
         MinersToolsMainHandToolBreakEvent.EVENT.register(player -> {

--- a/src/main/java/me/enchan/minerstools/bulk_break/BulkBreakDispatcher.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/BulkBreakDispatcher.java
@@ -6,25 +6,38 @@ import me.enchan.minerstools.bulk_break.strategy.BulkBreakStrategy;
 import me.enchan.minerstools.bulk_break.strategy.FellingStrategy;
 import me.enchan.minerstools.bulk_break.strategy.HarvestingStrategy;
 import me.enchan.minerstools.bulk_break.strategy.MiningStrategy;
+import me.enchan.minerstools.bulk_break.strategy.OneShotStrategy;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 
 public class BulkBreakDispatcher {
-    private static final List<BulkBreakStrategy> Strategies = List.of(
+    private static final List<BulkBreakStrategy> DefaultStrategies = List.of(
             new FellingStrategy(),
             new MiningStrategy(),
             new HarvestingStrategy());
 
-    public static void onBreakBlock(
+    /** ワンショットモード (一度だけ大規模破壊) フラグ */
+    private boolean isOneshotModeEnabled;
+
+    public BulkBreakDispatcher() {
+        this.isOneshotModeEnabled = false;
+    }
+
+    public void dispatchStrategy(
             ServerWorld world,
             BlockPos origin,
             PlayerEntity player,
             BlockState originState) {
         var tool = player.getMainHandStack();
 
-        Strategies.stream()
+        var strategies = DefaultStrategies;
+        if (isOneshotModeEnabled) {
+            strategies = List.of(new OneShotStrategy());
+        }
+
+        strategies.stream()
                 .filter(s -> s.matches(originState, player, tool))
                 .findFirst()
                 .ifPresent(s -> {
@@ -34,5 +47,15 @@ public class BulkBreakDispatcher {
                         s.harvest(world, pos, player);
                     }
                 });
+
+        isOneshotModeEnabled = false;
+    }
+
+    public void enableOneshotMode() {
+        this.isOneshotModeEnabled = true;
+    }
+
+    public void disableOneshotMode() {
+        this.isOneshotModeEnabled = false;
     }
 }

--- a/src/main/java/me/enchan/minerstools/bulk_break/BulkBreakDispatcher.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/BulkBreakDispatcher.java
@@ -18,22 +18,16 @@ public class BulkBreakDispatcher {
             new MiningStrategy(),
             new HarvestingStrategy());
 
-    /** ワンショットモード (一度だけ大規模破壊) フラグ */
-    private boolean isOneshotModeEnabled;
-
-    public BulkBreakDispatcher() {
-        this.isOneshotModeEnabled = false;
-    }
-
-    public void dispatchStrategy(
+    public static void dispatchStrategy(
             ServerWorld world,
             BlockPos origin,
             PlayerEntity player,
-            BlockState originState) {
+            BlockState originState,
+            boolean isOneshotMode) {
         var tool = player.getMainHandStack();
 
         var strategies = DefaultStrategies;
-        if (isOneshotModeEnabled) {
+        if (isOneshotMode) {
             strategies = List.of(new OneShotStrategy());
         }
 
@@ -47,15 +41,5 @@ public class BulkBreakDispatcher {
                         s.harvest(world, pos, player);
                     }
                 });
-
-        isOneshotModeEnabled = false;
-    }
-
-    public void enableOneshotMode() {
-        this.isOneshotModeEnabled = true;
-    }
-
-    public void disableOneshotMode() {
-        this.isOneshotModeEnabled = false;
     }
 }

--- a/src/main/java/me/enchan/minerstools/bulk_break/strategy/OneShotStrategy.java
+++ b/src/main/java/me/enchan/minerstools/bulk_break/strategy/OneShotStrategy.java
@@ -1,0 +1,54 @@
+package me.enchan.minerstools.bulk_break.strategy;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+
+public class OneShotStrategy implements BulkBreakStrategy {
+
+    @Override
+    public boolean matches(BlockState state, PlayerEntity player, ItemStack tool) {
+        // ちょっと危ないかも?
+        return true;
+    }
+
+    @Override
+    public Set<BlockPos> collectTargets(ServerWorld world, BlockPos origin, BlockState originState) {
+        var visited = new HashSet<BlockPos>();
+        var queue = new ArrayDeque<BlockPos>();
+
+        var maxChainDistance = 6;
+
+        visited.add(origin);
+        queue.add(origin);
+
+        while (!queue.isEmpty()) {
+            var pos = queue.poll();
+
+            BlockPos
+                    .stream(pos.add(-1, -1, -1), pos.add(1, 1, 1))
+                    .map(BlockPos::toImmutable)
+                    .filter(p -> !visited.contains(p))
+                    .filter(p -> p.isWithinDistance(origin, maxChainDistance))
+                    .filter(p -> {
+                        var state = world.getBlockState(p);
+                        return state.getBlock().equals(originState.getBlock());
+                    })
+                    .forEach(p -> {
+                        visited.add(p);
+                        queue.add(p);
+                    });
+        }
+
+        // このメソッドが呼び出された時点で起点のブロックは破壊されているので、候補から除外
+        visited.remove(origin);
+        return visited;
+    }
+
+}

--- a/src/main/java/me/enchan/minerstools/payloads/MinersToolsOneshotTriggerPayload.java
+++ b/src/main/java/me/enchan/minerstools/payloads/MinersToolsOneshotTriggerPayload.java
@@ -1,0 +1,20 @@
+package me.enchan.minerstools.payloads;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+public record MinersToolsOneshotTriggerPayload() implements CustomPayload {
+    public static final Id<MinersToolsOneshotTriggerPayload> ID = new Id<>(
+            Identifier.of("miners-tools", "oneshot-trigger"));
+
+    public static final MinersToolsOneshotTriggerPayload INSTANCE = new MinersToolsOneshotTriggerPayload();
+
+    public static final PacketCodec<PacketByteBuf, MinersToolsOneshotTriggerPayload> CODEC = PacketCodec.unit(INSTANCE);
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+}


### PR DESCRIPTION
Fixes: #18

- **feat: #18 ワンショット破壊ストラテジを実装**
- **feat: #18 ディスパッチャにワンショットモードフラグを追加, モードによって戦略を切り替えられるように**
- **feat: #18 ワンショットトリガペイロードを定義**
- **feat: #18 ペイロードを受け取ってワンショットモードに切り替えられるようにした**
